### PR TITLE
Remove additional column

### DIFF
--- a/share/Status-Tracker.md
+++ b/share/Status-Tracker.md
@@ -117,7 +117,7 @@ Letters indicate which platform versions have been tested successfully:
 |Her Name Was Fire	|Godot	|W	|	|	|	|	|		|
 |Heroes of Loot		|LibGDX	|	|	|L	|	|	|		|
 |Hexes			|Godot	|L	|	|	|	|	|		|
-|Hexis		|	|Godot	|L	|	|	|	|	|		|
+|Hexis		|Godot	|L	|	|	|	|	|	|
 |Hive			|FNA	|L	|	|	|	|	|		|
 |Hoarder's Horrible House of Stuff|Love2D||	|L	|	|	|		|
 |Hyphen			|FNA	|L	|	|	|	|	|unlisted on Steam. Still on humblebundle.|


### PR DESCRIPTION
I removed the additinal colum for Hexis. I am not sure the `L` is meant to be for GOG or Steam, though.